### PR TITLE
Use the right module name in go.mod so it can be fetched

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module vpereira/nrped
+module github.com/vpereira/nrped
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
-module github.com/vpereira/nrped
+module github.com/canonical/nrped
 
 go 1.16
 
 require (
 	github.com/droundy/goopt v0.0.0-20170604162106-0b8effe182da
 	github.com/jimlawless/cfg v0.0.0-20160326141742-136e0c264d31
-	github.com/vpereira/nrped v0.0.0-20211117191835-7c238f152fa1
+	github.com/canonical/nrped v0.0.0-20211117191835-7c238f152fa1
 )


### PR DESCRIPTION
As the title -- right now `go get vpereira/nrped` cannot be completed. The module name should be fully qualified.